### PR TITLE
iOS - EI - App crashes when opening "Delivery Status Notification (Failure)" email

### DIFF
--- a/lib/streams.js
+++ b/lib/streams.js
@@ -133,9 +133,6 @@ BinaryStream.prototype._transform = function(data, encoding, done) {
 };
 
 BinaryStream.prototype._flush = function(done) {
-    if (data && data.length) {
-        this.push(data);
-    }
     this.emit("meta-data", {
         length: this.length,
         checksum: this.checksum.digest("hex")


### PR DESCRIPTION
When changing from classic streams to new streams API. I failed to delete the handling of a final data chunk in the flush method (since this no longer happens). This was causing emails that have binary streams to crash the APP.